### PR TITLE
Fix a bug where char type length was inconsistent

### DIFF
--- a/tests/test_unformatted_read_write.py
+++ b/tests/test_unformatted_read_write.py
@@ -12,6 +12,7 @@ from ecl_data_io._unformatted.write import unformatted_write
     "data",
     [
         [("KEYWORD1", [1, 2, 3])],
+        [("KEYWORD1", [""])],
         [
             ("KEYWORD1", [1, 2, 3]),
             ("22222222", np.array([1.1, 2.1, 3.1])),
@@ -39,6 +40,9 @@ def test_unformatted_write(container, data):
     for (kw, arr), okw, oarr in zip(data, out_keywords, out_arrays):
         assert kw == okw
         if isinstance(arr[0], str):
-            assert np.array_equal([el.encode("ascii") for el in arr], oarr)
+            for el, elo in zip(arr, oarr):
+                elo = elo.decode("ascii")
+                assert elo.startswith(el)
+                assert all(c.isspace() for c in elo[len(el) :])
         else:
             assert np.array_equal(arr, oarr)

--- a/tests/test_unformatted_write.py
+++ b/tests/test_unformatted_write.py
@@ -95,7 +95,7 @@ def test_write_str_list_too_long():
     str_list = ["a" * 200]
 
     with pytest.raises(ValueError, match="strings of length"):
-        ecl_unf_write.write_str_list(buf, str_list)
+        ecl_unf_write.write_str_list(buf, str_list, b"CHAR")
 
 
 def test_write_str_list_non_ascii():
@@ -103,14 +103,14 @@ def test_write_str_list_non_ascii():
     str_list = ["\u2167"]
 
     with pytest.raises(ValueError, match="non-ascii"):
-        ecl_unf_write.write_str_list(buf, str_list)
+        ecl_unf_write.write_str_list(buf, str_list, b"CHAR")
 
 
 def test_write_str_list_char():
     buf = io.BytesIO()
     str_list = ["a" * 8, "b" * 4]
 
-    ecl_unf_write.write_str_list(buf, str_list)
+    ecl_unf_write.write_str_list(buf, str_list, b"CHAR")
 
     marker = (16).to_bytes(4, byteorder="big", signed=True)
 


### PR DESCRIPTION
For zero length byte strings, numpy reports its type as being "S1" and its itemsize as 1 byte long. To avoid a disparity, unified how type length is computed for strings when writing. Instead of recomputing the length of the items in an array of strings, use the item size reported when generating the type.