### PR TITLE
Use stricter adherence to formatted specification

### DIFF
--- a/src/ecl_data_io/_formatted/write.py
+++ b/src/ecl_data_io/_formatted/write.py
@@ -16,9 +16,9 @@ def write_str_list(stream, str_list):
     str_list = [s.decode("ascii") if not isinstance(s, str) else s for s in str_list]
 
     for i, string in enumerate(str_list):
-        stream.write(f" '{string.ljust(max_len)}'")
-        if i % 4 == 3:
+        if i % 7 == 0:
             stream.write("\n")
+        stream.write(f" '{string.ljust(max_len)}'")
 
 
 def write_np_array(stream, array, ecl_type):
@@ -32,27 +32,27 @@ def write_np_array(stream, array, ecl_type):
     """
     if ecl_type == b"LOGI":
         for i, ele in enumerate(array):
-            if ele:
-                stream.write(" T")
-            else:
-                stream.write(" F")
-            if i % 4 == 3:
+            if i % 25 == 0:
                 stream.write("\n")
+            if ele:
+                stream.write("  T")
+            else:
+                stream.write("  F")
     elif ecl_type == b"REAL":
         for i, ele in enumerate(array):
-            stream.write(" {:16.8E}".format(ele))
-            if i % 4 == 3:
+            if i % 4 == 0:
                 stream.write("\n")
+            stream.write(" {:>16.8E}".format(ele))
     elif ecl_type == b"DOUB":
         for i, ele in enumerate(array):
-            stream.write(" {:22.14E}".format(ele))
-            if i % 4 == 3:
+            if i % 3 == 0:
                 stream.write("\n")
+            stream.write(" {:>22.14E}".format(ele).replace("E", "D"))
     elif ecl_type == b"INTE":
         for i, ele in enumerate(array):
-            stream.write(" {:10d}".format(ele))
-            if i % 4 == 3:
+            if i % 6 == 0:
                 stream.write("\n")
+            stream.write(" {:>11d}".format(ele))
 
 
 def write_entry(stream, keyword, array_like):
@@ -66,7 +66,7 @@ def write_entry(stream, keyword, array_like):
     array = np.asarray(array_like)
     ecl_type = ecl_types.from_np_dtype(array)
     stream.write(
-        f"'{keyword.ljust(8)}' {len(array)} '{ecl_type.decode('ascii').ljust(4)}'\n"
+        f" '{keyword.ljust(8)}' {' {:>10d}'.format(len(array))} '{ecl_type.decode('ascii').ljust(4)}'"
     )
 
     if np.issubdtype(array.dtype, np.str_) or array.dtype.char == "S":

--- a/tests/test_formatted_write.py
+++ b/tests/test_formatted_write.py
@@ -1,10 +1,65 @@
 import io
 
 import ecl_data_io._formatted.write as ecl_io_fwrite
+import numpy as np
 
 
 def test_write_str_list():
     buf = io.StringIO()
     ecl_io_fwrite.write_str_list(buf, ["a", "bb"])
 
-    assert buf.getvalue() == " 'a ' 'bb'"
+    assert buf.getvalue() == "\n 'a ' 'bb'"
+
+
+def test_write_str():
+    buf = io.StringIO()
+    ecl_io_fwrite.formatted_write(buf, [("ZGRP    ", ["12345678"] * 8)])
+
+    assert (
+        buf.getvalue()
+        == """ 'ZGRP    '           8 'CHAR'
+ '12345678' '12345678' '12345678' '12345678' '12345678' '12345678' '12345678'
+ '12345678'\n"""
+    )
+
+
+def test_write_int():
+    buf = io.StringIO()
+    ecl_io_fwrite.formatted_write(
+        buf, [("FILEHEAD", np.zeros(shape=(7,), dtype=np.int32))]
+    )
+
+    assert (
+        buf.getvalue()
+        == """ 'FILEHEAD'           7 'INTE'
+           0           0           0           0           0           0
+           0\n"""
+    )
+
+
+def test_write_logi():
+    buf = io.StringIO()
+    ecl_io_fwrite.formatted_write(
+        buf, [("LOGIHEAD", np.zeros(shape=(26,), dtype=np.bool))]
+    )
+
+    assert (
+        buf.getvalue()
+        == """ 'LOGIHEAD'          26 'LOGI'
+  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F  F
+  F\n"""
+    )
+
+
+def test_write_doub():
+    buf = io.StringIO()
+    ecl_io_fwrite.formatted_write(
+        buf, [("DOUBHEAD", np.zeros(shape=(4,), dtype=np.float64))]
+    )
+
+    assert (
+        buf.getvalue()
+        == """ 'DOUBHEAD'           4 'DOUB'
+   0.00000000000000D+00   0.00000000000000D+00   0.00000000000000D+00
+   0.00000000000000D+00\n"""
+    )


### PR DESCRIPTION
The formatted io was previously tested against a lenient implementation
of read/write. However, simulators such as opm flow is much stricter in
what it accepts.

Changed the implementation so that it follows the specification expected
by OPM flow.