### PR TITLE
add functionality for writing MESS type

### DIFF
--- a/src/ecl_data_io/_formatted/write.py
+++ b/src/ecl_data_io/_formatted/write.py
@@ -65,9 +65,14 @@ def write_entry(stream, keyword, array_like):
     """
     array = np.asarray(array_like)
     ecl_type = ecl_types.from_np_dtype(array)
-    stream.write(
-        f" '{keyword.ljust(8)}' {' {:>10d}'.format(len(array))} '{ecl_type.decode('ascii').ljust(4)}'"
-    )
+    if ecl_type == b"MESS":
+        stream.write(
+            f" '{keyword.ljust(8)}' {' {:>10d}'.format(0)} '{ecl_type.decode('ascii').ljust(4)}'"
+        )
+    else:
+        stream.write(
+            f" '{keyword.ljust(8)}' {' {:>10d}'.format(len(array))} '{ecl_type.decode('ascii').ljust(4)}'"
+        )
 
     if np.issubdtype(array.dtype, np.str_) or array.dtype.char == "S":
         write_str_list(stream, array.tolist())

--- a/src/ecl_data_io/_unformatted/read.py
+++ b/src/ecl_data_io/_unformatted/read.py
@@ -121,7 +121,7 @@ class UnformattedEclArray(EclArray):
         self._read_record_marker(16)
         if self._type == b"X231":
             self._read_record_marker(16)
-            self._length *= -(2 ** 31)
+            self._length *= -(2**31)
             previous_keyword = self._keyword
             self._read_keyword()
             if previous_keyword != self._keyword:

--- a/src/ecl_data_io/_unformatted/write.py
+++ b/src/ecl_data_io/_unformatted/write.py
@@ -15,9 +15,9 @@ def write_array_header(stream, kw_str, type_str, size):
     if not ecl_types.is_valid_type(type_str):
         raise EclWriteError(f"Not a valid ecl type: {type_str}")
 
-    if size > 2 ** 31:
-        write_array_header(stream, kw_str, b"X231", -(size // (2 ** 31)))
-        size %= 2 ** 31
+    if size > 2**31:
+        write_array_header(stream, kw_str, b"X231", -(size // (2**31)))
+        size %= 2**31
 
     stream.write((16).to_bytes(4, byteorder="big", signed=True))
     stream.write(kw_str.encode("ascii"))

--- a/src/ecl_data_io/_unformatted/write.py
+++ b/src/ecl_data_io/_unformatted/write.py
@@ -101,7 +101,11 @@ def write_str_list(stream, str_list, ecl_type):
 def write_array_like(stream, keyword, array_like):
     array = np.asarray(array_like)
     ecl_type = ecl_types.from_np_dtype(array)
-    write_array_header(stream, keyword, ecl_type, len(array))
+    if ecl_type == b"MESS":
+        write_array_header(stream, keyword, ecl_type, 0)
+        array = np.array([])
+    else:
+        write_array_header(stream, keyword, ecl_type, len(array))
     if np.issubdtype(array.dtype, np.str_) or array.dtype.char == "S":
         write_str_list(stream, array.tolist(), ecl_type)
     else:

--- a/src/ecl_data_io/types.py
+++ b/src/ecl_data_io/types.py
@@ -35,6 +35,8 @@ static_dtypes = {
     b"CHAR": np.dtype("|S8"),
 }
 
+MESS = None
+
 
 def to_np_type(type_keyword):
     """
@@ -54,6 +56,8 @@ def from_np_dtype(array):
         given numpy array's dtype.
     """
     dtype = array.dtype
+    if dtype == "object" and array == MESS:
+        return b"MESS"
     if dtype in [np.dtype(np.int32), np.dtype(np.int32).newbyteorder(">")]:
         return b"INTE"
     if dtype in [np.dtype(np.int64), np.dtype(np.int64).newbyteorder(">")]:

--- a/tests/test_formatted_write.py
+++ b/tests/test_formatted_write.py
@@ -1,5 +1,6 @@
 import io
 
+from ecl_data_io.types import MESS
 import ecl_data_io._formatted.write as ecl_io_fwrite
 import numpy as np
 
@@ -63,3 +64,15 @@ def test_write_doub():
    0.00000000000000D+00   0.00000000000000D+00   0.00000000000000D+00
    0.00000000000000D+00\n"""
     )
+
+
+def test_write_mess():
+    buf = io.StringIO()
+    ecl_io_fwrite.formatted_write(
+        buf, [("MESSHEAD", MESS)]
+    )
+    assert (
+        buf.getvalue()
+        == """ 'MESSHEAD'           0 'MESS'\n"""
+    )
+

--- a/tests/test_formatted_write.py
+++ b/tests/test_formatted_write.py
@@ -68,11 +68,5 @@ def test_write_doub():
 
 def test_write_mess():
     buf = io.StringIO()
-    ecl_io_fwrite.formatted_write(
-        buf, [("MESSHEAD", MESS)]
-    )
-    assert (
-        buf.getvalue()
-        == """ 'MESSHEAD'           0 'MESS'\n"""
-    )
-
+    ecl_io_fwrite.formatted_write(buf, [("MESSHEAD", MESS)])
+    assert buf.getvalue() == """ 'MESSHEAD'           0 'MESS'\n"""

--- a/tests/test_unformatted_write.py
+++ b/tests/test_unformatted_write.py
@@ -125,4 +125,6 @@ def test_write_mess():
 
     marker = (16).to_bytes(4, byteorder="big", signed=True)
 
-    assert buf.getvalue() == marker + b"MESSHEAD" + b"\x00\x00\x00\x00" + b"MESS" + marker
+    assert (
+        buf.getvalue() == marker + b"MESSHEAD" + b"\x00\x00\x00\x00" + b"MESS" + marker
+    )

--- a/tests/test_unformatted_write.py
+++ b/tests/test_unformatted_write.py
@@ -3,6 +3,7 @@ import io
 import numpy as np
 import pytest
 
+from ecl_data_io.types import MESS
 import ecl_data_io._unformatted.write as ecl_unf_write
 
 
@@ -115,3 +116,13 @@ def test_write_str_list_char():
     marker = (16).to_bytes(4, byteorder="big", signed=True)
 
     assert buf.getvalue() == marker + b"a" * 8 + b"b" * 4 + b" " * 4 + marker
+
+
+def test_write_mess():
+    buf = io.BytesIO()
+
+    ecl_unf_write.unformatted_write(buf, [("MESSHEAD", MESS)])
+
+    marker = (16).to_bytes(4, byteorder="big", signed=True)
+
+    assert buf.getvalue() == marker + b"MESSHEAD" + b"\x00\x00\x00\x00" + b"MESS" + marker


### PR DESCRIPTION
Added a sentinel value for MESS type (None) in order to write MESS type data. Has to be in format [(keyword, MESS)]. See: https://github.com/equinor/ecl-data-io/issues/11