### PR TITLE
Implement update

### DIFF
--- a/docs/source/api_doc.rst
+++ b/docs/source/api_doc.rst
@@ -10,3 +10,6 @@ API-Doc
 .. autoclass:: ecl_data_io.Format
 
 .. autoclass:: ecl_data_io.MESS
+
+.. autoclass:: ecl_data_io.array_entry.EclArray
+   :members:

--- a/docs/source/example_usage.rst
+++ b/docs/source/example_usage.rst
@@ -98,3 +98,24 @@ numpy dtypes are mapped to ecl file types as follows:
 * LOGI to `bool`
 * CHAR to `string` (or `numpy.dtype("|S8")`)
 * C0XX to `numpy.dtype("|SXX")`
+
+Updating
+--------
+
+It is possible to do an in-place update of an array in an existing
+file, by passing a stream opened for both read and write. The array
+cannot change type or size.
+
+Say you want to update the first keyword name `"OLD_NAME"`, change the array
+to `new_array` and the name to `NEW_NAME`, then that can be done
+with the following:
+
+>>> import ecl_data_io as eclio
+>>>
+>>> new_array = ...
+>>>
+>>> with open("my_grid.egrid", "br+") as f: # Open with read and write
+...     for entry in eclio.lazy_read(f):
+...         if entry.read_keyword() == "OLD_NAME":
+...             entry.update(keyword="NEW_NAME", array=new_array)
+...             break

--- a/docs/source/example_usage.rst
+++ b/docs/source/example_usage.rst
@@ -68,7 +68,7 @@ For better control, one can pass the opened file:
 >>> import ecl_data_io as eclio
 >>>
 >>> with open("my_grid.egrid", "rb") as f:
-...     generator = eclio.lazy_read("my_grid.egrid")
+...     generator = eclio.lazy_read(f)
 ...     item = next(generator)
 ...     print(item.read_keyword())
 

--- a/src/ecl_data_io/_formatted/read.py
+++ b/src/ecl_data_io/_formatted/read.py
@@ -33,26 +33,6 @@ class FormattedEclArray(EclArray):
 
         self._is_eof = False
 
-    @property
-    def is_eof(self):
-        if self._keyword is None:
-            self._read()
-        return self._is_eof
-
-    def read_keyword(self):
-        if self._keyword is None:
-            self._read()
-        return self._keyword
-
-    def read_length(self):
-        """
-        Read the length from the formatted ecl file.
-        :returns: The length of the array in number of entries.
-        """
-        if self._length is None:
-            self._read()
-        return self._length
-
     def read_array(self):
         if self._keyword is None:
             self._read()

--- a/src/ecl_data_io/_formatted/read.py
+++ b/src/ecl_data_io/_formatted/read.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import ecl_data_io.types as ecl_types
+from ecl_data_io._formatted.write import write_entry
 from ecl_data_io.array_entry import EclArray
 from ecl_data_io.errors import EclParsingError
 
@@ -37,6 +38,9 @@ class FormattedEclArray(EclArray):
         if self._keyword is None:
             self._read()
         return self._read_array()
+
+    def update(self, *, keyword=None, array=None):
+        raise NotImplementedError("Update is not implemented for formatted files")
 
     def _read_logical(self):
         """

--- a/src/ecl_data_io/_unformatted/read.py
+++ b/src/ecl_data_io/_unformatted/read.py
@@ -1,7 +1,8 @@
 import io
 
-import ecl_data_io.types as ecl_io_types
 import numpy as np
+
+import ecl_data_io.types as ecl_types
 from ecl_data_io._unformatted.common import bytes_in_array, group_len, item_size
 from ecl_data_io.array_entry import EclArray
 from ecl_data_io.errors import EclParsingError
@@ -20,10 +21,10 @@ class UnformattedEclArray(EclArray):
         if self._data_start is None:
             self._read()
         if self._type == b"MESS":
-            return ecl_io_types.MESS
+            return ecl_types.MESS
         self.stream.seek(self._data_start)
         g_len = group_len(self._type)
-        np_type = ecl_io_types.to_np_type(self._type)
+        np_type = ecl_types.to_np_type(self._type)
         array = np.zeros(shape=(self._length,), dtype=np_type)
         to_read = self._length
         type_len = item_size(self._type)

--- a/src/ecl_data_io/_unformatted/read.py
+++ b/src/ecl_data_io/_unformatted/read.py
@@ -12,24 +12,6 @@ class UnformattedEclArray(EclArray):
     An array entry in a unformatted ecl file.
     """
 
-    def read_keyword(self):
-        """
-        Read the keyword from the unformatted ecl file.
-        :returns: The keyword as a 8 character string.
-        """
-        if self._keyword is None:
-            self._read()
-        return self._keyword.decode("ascii")
-
-    def read_length(self):
-        """
-        Read the length from the unformatted ecl file.
-        :returns: The length of the array in number of entries.
-        """
-        if self._length is None:
-            self._read()
-        return self._length
-
     def read_array(self):
         """
         Read the array from the unformatted ecl file.
@@ -40,7 +22,7 @@ class UnformattedEclArray(EclArray):
         if self._type == b"MESS":
             return ecl_io_types.MESS
         self.stream.seek(self._data_start)
-        g_len = group_len(self.type)
+        g_len = group_len(self._type)
         np_type = ecl_io_types.to_np_type(self._type)
         array = np.zeros(shape=(self._length,), dtype=np_type)
         to_read = self._length
@@ -79,7 +61,7 @@ class UnformattedEclArray(EclArray):
         With stream.peek() at the start of the keyword, reads
         it into self._keyword
         """
-        self._keyword = self.stream.read(8)
+        self._keyword = self.stream.read(8).decode("ascii")
         if not self._keyword or len(self._keyword) < 8:
             raise EclParsingError("Reached end-of-file while reading keyword")
 
@@ -146,7 +128,7 @@ class UnformattedEclArray(EclArray):
                 f"has item length {type_len} which requires 0 number of"
                 f"elements, but found {self._length} amount of elements."
             )
-        bytes_to_skip = bytes_in_array(self._length, self.type)
+        bytes_to_skip = bytes_in_array(self._length, self._type)
 
         self._data_start = self.stream.tell()
         self.stream.seek(bytes_to_skip, io.SEEK_CUR)

--- a/src/ecl_data_io/_unformatted/write.py
+++ b/src/ecl_data_io/_unformatted/write.py
@@ -27,7 +27,7 @@ def write_array_header(stream, kw_str, type_str, size):
 
 
 def cast_array_to_ecl(arr):
-    if arr.dtype in [np.int32, np.float32, np.float64]:
+    if arr.dtype.type in [np.int32, np.float32, np.float64]:
         return arr.astype(arr.dtype.newbyteorder(">"))
     if np.issubdtype(arr.dtype, np.bool_):
         return -arr.astype(">i4")

--- a/src/ecl_data_io/array_entry.py
+++ b/src/ecl_data_io/array_entry.py
@@ -1,16 +1,12 @@
-import io
 from abc import ABC, abstractmethod
-
-import numpy as np
-
-import ecl_data_io.types as ecl_io_types
-from ecl_data_io._unformatted.common import group_len, item_size
-from ecl_data_io.errors import EclParsingError
 
 
 class EclArray(ABC):
     """
     An array entry in a ecl file.
+
+    This class is not ment to be constructed directly, but rather
+    generated e.g. :py:meth:`ecl_data_io.lazy_read`.
     """
 
     def __init__(self, stream):
@@ -39,47 +35,42 @@ class EclArray(ABC):
             self._read()
         return self._is_eof
 
-    @abstractmethod
     def read_keyword(self):
         """
         Read the keyword from the ecl file.
+
         :returns: The keyword as a 8 character string.
         """
-        pass
+        if self._keyword is None:
+            self._read()
+        return self._keyword
 
-    @abstractmethod
     def read_length(self):
         """
         Read the length from the ecl file.
+
         :returns: The length of the array in number of entries.
         """
-        pass
+        if self._length is None:
+            self._read()
+        return self._length
 
     @abstractmethod
     def read_array(self):
         """
         Read the array from the unformatted ecl file.
+
         :returns: numpy array of values.
         """
         pass
 
-    @property
-    def type(self):
+    def read_type(self):
         """
         The type given in the header of the array
         """
         if self._type is None:
             self._read()
         return self._type
-
-    @property
-    def length(self):
-        """
-        The length given in the header of the array
-        """
-        if self._length is None:
-            self._read()
-        return self._length
 
     @abstractmethod
     def _read(self):

--- a/src/ecl_data_io/array_entry.py
+++ b/src/ecl_data_io/array_entry.py
@@ -73,6 +73,22 @@ class EclArray(ABC):
         return self._type
 
     @abstractmethod
+    def update(self, *, keyword=None, array=None):
+        """
+        Updates the entry with the given new data.
+
+        :param new_keyword: The new keyword, must be 8 characters, defaults to no change.
+        :param new_array: The new array, must be of same type and size
+            as existing array, defaults to no change.
+
+        :raises ValueError: If array does not have the same type or length as
+            existing array.
+        :raises io.UnsupportedOperation: If the underlying stream has been opened
+            with the wrong mode (file must be opened with "r+" in order to correctly update)
+        """
+        pass
+
+    @abstractmethod
     def _read(self):
         """
         Reads the array entry. Guarantees that after, either entry.is_eof() and

--- a/tests/test_formatted_read.py
+++ b/tests/test_formatted_read.py
@@ -28,8 +28,8 @@ def test_simple_ecl_array_read(tmp_path):
     with (tmp_path / "test.txt").open("r") as f:
         ecl_arr = ecl_read.FormattedEclArray(f)
 
-        assert ecl_arr.type == b"INTE"
-        assert ecl_arr.length == 4
+        assert ecl_arr.read_type() == b"INTE"
+        assert ecl_arr.read_length() == 4
         assert ecl_arr.read_keyword() == "SPECGRID"
         assert np.array_equal(ecl_arr.read_array(), [40, 64, 14, 1])
 
@@ -43,8 +43,8 @@ def test_simple_ecl_char_array_read(tmp_path):
     with (tmp_path / "test.txt").open("r") as f:
         ecl_arr = ecl_read.FormattedEclArray(f)
 
-        assert ecl_arr.type == b"CHAR"
-        assert ecl_arr.length == 2
+        assert ecl_arr.read_type() == b"CHAR"
+        assert ecl_arr.read_length() == 2
         assert ecl_arr.read_keyword() == "CHARARR1"
         assert np.array_equal(ecl_arr.read_array(), ["HELLO   ", "WORLD   "])
 
@@ -58,7 +58,7 @@ def test_simple_ecl_logi_array_read(tmp_path):
     with (tmp_path / "test.txt").open("r") as f:
         ecl_arr = ecl_read.FormattedEclArray(f)
 
-        assert ecl_arr.type == b"LOGI"
-        assert ecl_arr.length == 2
+        assert ecl_arr.read_type() == b"LOGI"
+        assert ecl_arr.read_length() == 2
         assert ecl_arr.read_keyword() == "KEYWORD1"
         assert np.array_equal(ecl_arr.read_array(), [True, False])

--- a/tests/test_formatted_read_write.py
+++ b/tests/test_formatted_read_write.py
@@ -1,5 +1,3 @@
-import io
-
 import numpy as np
 import pytest
 
@@ -7,6 +5,7 @@ from ecl_data_io._formatted.read import FormattedEclArray
 from ecl_data_io._formatted.write import formatted_write
 
 
+@pytest.mark.filterwarnings("ignore:downcasting")
 @pytest.mark.parametrize("container", [dict, lambda x: x])
 @pytest.mark.parametrize(
     "data",

--- a/tests/test_formatted_write.py
+++ b/tests/test_formatted_write.py
@@ -52,6 +52,19 @@ def test_write_logi():
     )
 
 
+def test_write_real():
+    buf = io.StringIO()
+    ecl_io_fwrite.formatted_write(
+        buf, [("REALHEAD", np.zeros(shape=(4,), dtype=np.float32))]
+    )
+
+    assert (
+        buf.getvalue()
+        == """ 'REALHEAD'           4 'REAL'
+   0.00000000E+00   0.00000000E+00   0.00000000E+00   0.00000000E+00\n"""
+    )
+
+
 def test_write_doub():
     buf = io.StringIO()
     ecl_io_fwrite.formatted_write(

--- a/tests/test_formatted_write.py
+++ b/tests/test_formatted_write.py
@@ -41,7 +41,7 @@ def test_write_int():
 def test_write_logi():
     buf = io.StringIO()
     ecl_io_fwrite.formatted_write(
-        buf, [("LOGIHEAD", np.zeros(shape=(26,), dtype=np.bool))]
+        buf, [("LOGIHEAD", np.zeros(shape=(26,), dtype=np.bool_))]
     )
 
     assert (

--- a/tests/test_unformatted_read.py
+++ b/tests/test_unformatted_read.py
@@ -24,19 +24,19 @@ def test_unformatted_ecl_array_simple_read(simple_unformatted_buffer):
     ecl_arr = ecl_io_uf.UnformattedEclArray(simple_unformatted_buffer)
     assert not ecl_arr.is_eof
     assert ecl_arr.read_keyword() == "KEYWORD1"
-    assert ecl_arr.type == b"INTE"
-    assert ecl_arr.length == 1
+    assert ecl_arr.read_type() == b"INTE"
+    assert ecl_arr.read_length() == 1
     assert np.array_equal(ecl_arr.read_array(), np.zeros(shape=(1,), dtype=">i4"))
 
 
 def test_unformatted_ecl_array_simple_type_loads(simple_unformatted_buffer):
     ecl_arr = ecl_io_uf.UnformattedEclArray(simple_unformatted_buffer)
-    assert ecl_arr.type == b"INTE"
+    assert ecl_arr.read_type() == b"INTE"
 
 
 def test_unformatted_ecl_array_simple_length_loads(simple_unformatted_buffer):
     ecl_arr = ecl_io_uf.UnformattedEclArray(simple_unformatted_buffer)
-    assert ecl_arr.length == 1
+    assert ecl_arr.read_length() == 1
 
 
 def test_unformatted_ecl_array_big_read():
@@ -59,8 +59,8 @@ def test_unformatted_ecl_array_big_read():
     ecl_arr = ecl_io_uf.UnformattedEclArray(buf)
     assert not ecl_arr.is_eof
     assert ecl_arr.read_keyword() == "KEYWORD1"
-    assert ecl_arr.type == b"INTE"
-    assert ecl_arr.length == 2300
+    assert ecl_arr.read_type() == b"INTE"
+    assert ecl_arr.read_length() == 2300
     assert np.array_equal(ecl_arr.read_array(), np.ones(shape=(2300,), dtype=">i4"))
 
 
@@ -194,8 +194,8 @@ def test_unformatted_simple_unformatted_parse():
     for ecl_arr in ecl_io_uf.UnformattedEclArray.parse(buf):
         assert not ecl_arr.is_eof
         assert ecl_arr.read_keyword() == "KEYWORD1"
-        assert ecl_arr.type == b"INTE"
-        assert ecl_arr.length == 1
+        assert ecl_arr.read_type() == b"INTE"
+        assert ecl_arr.read_length() == 1
         assert np.array_equal(ecl_arr.read_array(), np.zeros(shape=(1,), dtype=">i4"))
 
     buf.seek(0)
@@ -227,8 +227,8 @@ def test_unformatted_x231_parse():
     for ecl_arr in ecl_io_uf.UnformattedEclArray.parse(buf):
         assert not ecl_arr.is_eof
         assert ecl_arr.read_keyword() == "KEYWORD1"
-        assert ecl_arr.type == b"INTE"
-        assert ecl_arr.length == 5000000000
+        assert ecl_arr.read_type() == b"INTE"
+        assert ecl_arr.read_length() == 5000000000
 
     buf.seek(0)
 
@@ -268,8 +268,8 @@ def test_unformatted_parse_mess():
     for ecl_arr in ecl_io_uf.UnformattedEclArray.parse(buf):
         assert not ecl_arr.is_eof
         assert ecl_arr.read_keyword() == "KEYWORD1"
-        assert ecl_arr.type == b"MESS"
-        assert ecl_arr.length == 0
+        assert ecl_arr.read_type() == b"MESS"
+        assert ecl_arr.read_length() == 0
 
     buf.seek(0)
 

--- a/tests/test_unformatted_read_write.py
+++ b/tests/test_unformatted_read_write.py
@@ -7,6 +7,8 @@ from ecl_data_io._unformatted.read import UnformattedEclArray
 from ecl_data_io._unformatted.write import unformatted_write
 
 
+@pytest.mark.filterwarnings("ignore:casting")
+@pytest.mark.filterwarnings("ignore:downcasting")
 @pytest.mark.parametrize("container", [dict, lambda x: x])
 @pytest.mark.parametrize(
     "data",

--- a/tests/test_unformatted_write.py
+++ b/tests/test_unformatted_write.py
@@ -50,6 +50,7 @@ def test_write_array_header_not_a_type():
         ecl_unf_write.write_array_header(buf, "KEYWORD1", b"NOTY", 3)
 
 
+@pytest.mark.filterwarnings("ignore:casting")
 @pytest.mark.parametrize(
     "array, expected_array",
     [
@@ -71,6 +72,7 @@ def test_cast_array_to_ecl_bad_type():
         ecl_unf_write.cast_array_to_ecl(array)
 
 
+@pytest.mark.filterwarnings("ignore:casting")
 def test_write_np_array():
     buf = io.BytesIO()
     ecl_unf_write.write_np_array(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,68 @@
+import io
+
+import hypothesis.strategies as st
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+
+from ecl_data_io import MESS, lazy_read, read, write
+
+from .generators import ecl_datas, float_arrays, keywords
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(data=st.lists(st.tuples(keywords, float_arrays)))
+def test_update(filelike, data):
+    data_zeros = [(kw, np.zeros(array.shape, dtype=array.dtype)) for kw, array in data]
+
+    write(filelike, data_zeros)
+    with open(filelike, "br+") as stream:
+        for entry, (kw, arr) in zip(lazy_read(stream), data):
+            assert kw == entry.read_keyword()
+            entry.update(keyword="NEW_NAME")
+            assert entry.read_array().tolist() == [0] * arr.size
+            assert entry.read_keyword() == "NEW_NAME"
+            entry.update(array=arr)
+            assert entry.read_array().tolist() == pytest.approx(arr.tolist())
+
+
+def test_update_mismatching_array_raises(filelike):
+    write(filelike, [("KEYWORD1", [True, False])])
+
+    with open(filelike, "br+") as stream:
+        reader = lazy_read(stream)
+        entry = next(reader)
+
+        with pytest.raises(ValueError, match="different size"):
+            entry.update(array=[True])
+
+        with pytest.raises(ValueError, match="different type"):
+            entry.update(array=["a", "b"])
+
+
+def test_update_incorrect_mode_raises(filelike):
+    write(filelike, [("KEYWORD1", [True, False])])
+
+    with open(filelike, "br") as stream:
+        entry = next(lazy_read(stream))
+        with pytest.raises(io.UnsupportedOperation):
+            entry.update(array=[False, False])
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(data=ecl_datas)
+def test_update_preserves_type(filelike, data):
+    write(filelike, data)
+    with open(filelike, "br+") as stream:
+        for (kw, arr), entry in zip(data, lazy_read(stream)):
+            entry.update(keyword=kw, array=arr)
+
+    for (kw, arr), (okw, oarr) in zip(data, read(filelike)):
+        assert kw == okw
+        if arr is MESS:
+            continue
+        if arr.dtype.type == np.str_:
+            # Allow reading to result in bytestring instead of string
+            assert oarr.dtype.type in [np.dtype("S8").type, np.dtype("<U8").type]
+        else:
+            assert arr.dtype.type == oarr.dtype.type


### PR DESCRIPTION
Implements update and does some general house cleaning:

* Fixes an error in the example usage
* Moves test generators into its own file
* Moves reusable fixture into conftest.py
* Filters expected warnings in tests
* Silences a warning about np.bool in tests
* Increases the test coverage of formatted write
* Use EclArray as a member of the API-doc
* Simplify EclArray so that it can be part of the public API.