### PR TITLE
Fixed issue with too strict unformatted keyword

### DIFF
--- a/src/ecl_data_io/_formatted/write.py
+++ b/src/ecl_data_io/_formatted/write.py
@@ -63,8 +63,13 @@ def write_entry(stream, keyword, array_like):
     :param keyword: 8-character string to use for keyword.
     :param array_like: Array of values to write.
     """
+    if "'" in keyword:
+        raise EclWriteError('keywords in formatted files cannot contain "\'"')
     array = np.asarray(array_like)
-    ecl_type = ecl_types.from_np_dtype(array)
+    try:
+        ecl_type = ecl_types.from_np_dtype(array)
+    except ValueError as e:
+        raise EclWriteError(f"{e}") from e
     if ecl_type == b"MESS":
         stream.write(
             f" '{keyword.ljust(8)}' {' {:>10d}'.format(0)} '{ecl_type.decode('ascii').ljust(4)}'"

--- a/src/ecl_data_io/_unformatted/write.py
+++ b/src/ecl_data_io/_unformatted/write.py
@@ -1,17 +1,14 @@
 import warnings
 
-import numpy as np
-
 import ecl_data_io.types as ecl_types
+import numpy as np
 from ecl_data_io._unformatted.common import group_len, item_size
 from ecl_data_io.errors import EclWriteError
 
 
 def write_array_header(stream, kw_str, type_str, size):
     if len(kw_str) != 8:
-        raise ValueError("keywords must have length exactly size 8")
-    if "'" in kw_str:
-        raise ValueError('keywords in formatted files cannot contain "\'"')
+        raise EclWriteError("keywords must have length exactly size 8")
     if not ecl_types.is_valid_type(type_str):
         raise EclWriteError(f"Not a valid ecl type: {type_str}")
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,29 @@
+from io import BytesIO, StringIO
+
+import pytest
+from ecl_data_io import EclParsingError, EclWriteError, Format, read, write
+
+
+def test_invalid_formatted_content():
+    file_contents = StringIO("Not valid ecl content")
+    with pytest.raises(EclParsingError, match='Expected "\'"'):
+        read(file_contents)
+
+
+def test_invalid_unformatted_content():
+    file_contents = BytesIO(b"\x00" * 100)
+    with pytest.raises(EclParsingError, match="Unexpected size of record"):
+        read(file_contents)
+
+
+@pytest.mark.parametrize(
+    "buffer, format", [(BytesIO(), Format.UNFORMATTED), (StringIO(), Format.FORMATTED)]
+)
+def test_invalid_read_content(buffer, format):
+    with pytest.raises(EclWriteError, match="Could not convert"):
+        write(buffer, [("FILEHEAD", "a" * 100)], format)
+
+
+def test_invalid_keyword():
+    with pytest.raises(EclWriteError, match="keywords"):
+        write(StringIO(), [("'", ["a" * 8])], Format.FORMATTED)


### PR DESCRIPTION
The keywords in unformatted files were incorrectly prohibited from containing ' (although most implementations likely will only permit upper case letters).