### PR TITLE
Rewind the stream on get_stream

### DIFF
--- a/src/ecl_data_io/format.py
+++ b/src/ecl_data_io/format.py
@@ -55,6 +55,7 @@ def get_stream(filepath, fileformat, mode="r"):
         else:
             return open(filepath, mode + "b"), True
     else:
+        filepath.seek(0)
         return filepath, False
 
 


### PR DESCRIPTION
When user passed file object instead of filename, the stream need to be re-winded so that it start from the beginning
