### PR TITLE
Fix deprecation warning

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: check-json
     -   id: check-yaml
@@ -8,6 +8,6 @@ repos:
     -   id: trailing-whitespace
 
 -   repo: https://github.com/ambv/black
-    rev: 22.6.0
+    rev: 23.3.0
     hooks:
     - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers=[
     "Development Status :: 1 - Planning",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/src/ecl_data_io/array_entry.py
+++ b/src/ecl_data_io/array_entry.py
@@ -1,4 +1,10 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from .types import ArrayValue
 
 
 class EclArray(ABC):
@@ -35,7 +41,7 @@ class EclArray(ABC):
             self._read()
         return self._is_eof
 
-    def read_keyword(self):
+    def read_keyword(self) -> str:
         """
         Read the keyword from the ecl file.
 
@@ -43,9 +49,9 @@ class EclArray(ABC):
         """
         if self._keyword is None:
             self._read()
-        return self._keyword
+        return self._keyword  # type: ignore
 
-    def read_length(self):
+    def read_length(self) -> int:
         """
         Read the length from the ecl file.
 
@@ -53,10 +59,10 @@ class EclArray(ABC):
         """
         if self._length is None:
             self._read()
-        return self._length
+        return self._length  # type: ignore
 
     @abstractmethod
-    def read_array(self):
+    def read_array(self) -> "ArrayValue":
         """
         Read the array from the unformatted ecl file.
 
@@ -64,16 +70,20 @@ class EclArray(ABC):
         """
         pass
 
-    def read_type(self):
+    def read_type(self) -> Union[str, bytes]:
         """
-        The type given in the header of the array
+        The type given in the header of the array.
+        In case of unformatted file this will be bytes, for
+        unformatted files it is str.
         """
         if self._type is None:
             self._read()
-        return self._type
+        return self._type  # type: ignore
 
     @abstractmethod
-    def update(self, *, keyword=None, array=None):
+    def update(
+        self, *, keyword: Optional[str] = None, array: Optional["ArrayLike"] = None
+    ):
         """
         Updates the entry with the given new data.
 

--- a/src/ecl_data_io/format.py
+++ b/src/ecl_data_io/format.py
@@ -41,7 +41,7 @@ def guess_format(filelike):
         return Format.FORMATTED
 
 
-def get_stream(filepath, fileformat, mode="r"):
+def get_stream(filepath, fileformat: Format, mode: str = "r"):
     """
     Openes the given file with the correct mode (text or binary)
     based on fileformat.
@@ -58,7 +58,7 @@ def get_stream(filepath, fileformat, mode="r"):
         return filepath, False
 
 
-def check_correct_mode(stream, fileformat):
+def check_correct_mode(stream, fileformat: Format):
     """
     Checks that the stream is the correct mode (text or binary) for the given
     fileformat.

--- a/src/ecl_data_io/read.py
+++ b/src/ecl_data_io/read.py
@@ -1,11 +1,15 @@
-from pathlib import Path
+from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple
 
 from ecl_data_io._formatted.read import FormattedEclArray
 from ecl_data_io._unformatted.read import UnformattedEclArray
+from ecl_data_io.array_entry import EclArray
 from ecl_data_io.format import Format, check_correct_mode, get_stream, guess_format
 
+if TYPE_CHECKING:
+    from .types import ArrayValue
 
-def read(*args, **kwargs):
+
+def read(*args, **kwargs) -> List[Tuple[str, "ArrayValue"]]:
     """
     Read the contents of a ecl file and return a list of
     tuples (keyword, array). Takes the same parameters as
@@ -16,7 +20,7 @@ def read(*args, **kwargs):
     ]
 
 
-def lazy_read(filelike, fileformat=None):
+def lazy_read(filelike, fileformat: Optional[Format] = None) -> Iterator[EclArray]:
     """
     Reads the contents of an ecl file and generates the entries
     of that file. Each entry has a entry.read_keyword() and

--- a/src/ecl_data_io/types.py
+++ b/src/ecl_data_io/types.py
@@ -23,8 +23,10 @@ that results in a warning.
 
 """
 import warnings
+from typing import Union
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 # np dtype for ecl types with fixed width
 static_dtypes = {
@@ -43,6 +45,9 @@ class MESS:
     """
 
     pass
+
+
+ArrayValue = Union[ArrayLike, MESS]
 
 
 def to_np_type(type_keyword):

--- a/src/ecl_data_io/version.py
+++ b/src/ecl_data_io/version.py
@@ -1,6 +1,6 @@
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version, PackageNotFoundError
 
 try:
-    version = get_distribution(__name__).version
-except DistributionNotFound:
+    version = version("ecl-data-io")
+except PackageNotFoundError:
     version = "0.0.0"

--- a/src/ecl_data_io/write.py
+++ b/src/ecl_data_io/write.py
@@ -1,11 +1,17 @@
-from pathlib import Path
+from typing import Dict, Sequence, Tuple, Union
 
 from ecl_data_io._formatted.write import formatted_write
 from ecl_data_io._unformatted.write import unformatted_write
 from ecl_data_io.format import Format, check_correct_mode, get_stream
 
+from .types import ArrayValue
 
-def write(filelike, contents, fileformat=Format.UNFORMATTED):
+
+def write(
+    filelike,
+    contents: Union[Sequence[Tuple[str, ArrayValue]], Dict[str, ArrayValue]],
+    fileformat: Format = Format.UNFORMATTED,
+):
     """
     Write the given contents to the given file in ecl format.
 

--- a/tests/test_formatted_read_write.py
+++ b/tests/test_formatted_read_write.py
@@ -24,7 +24,6 @@ from ecl_data_io._formatted.write import formatted_write
     ],
 )
 def test_formatted_write(container, data, tmp_path):
-
     with (tmp_path / "test.data").open("wt") as fh:
         formatted_write(fh, container(data))
 

--- a/tests/test_type_resolution.py
+++ b/tests/test_type_resolution.py
@@ -15,7 +15,6 @@ import pytest
     ],
 )
 def test_formatted_read_type_resolution(tmp_path, contents, expected_type):
-
     with (tmp_path / "test.txt").open("w") as f:
         f.write(contents)
 
@@ -37,7 +36,6 @@ def test_formatted_read_type_resolution(tmp_path, contents, expected_type):
     ],
 )
 def test_formatted_write_type_resolution(tmp_path, data, expected_type):
-
     file = tmp_path / "test.txt"
 
     with file.open("w") as f:
@@ -92,7 +90,6 @@ def keyword_start(ecl_type):
     ],
 )
 def test_unformatted_read_type_resolution(tmp_path, contents, expected_type):
-
     with (tmp_path / "test.txt").open("wb") as f:
         f.write(contents)
 

--- a/tests/test_type_resolution.py
+++ b/tests/test_type_resolution.py
@@ -110,8 +110,7 @@ def test_unformatted_read_type_resolution(tmp_path, contents, expected_type):
         ([True], b"LOGI"),
     ],
 )
-def test_formatted_write_type_resolution(tmp_path, data, expected_type):
-
+def test_unformatted_write_type_resolution(tmp_path, data, expected_type):
     file = tmp_path / "test.txt"
 
     with file.open("wb") as f:

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 isolated_build = True
 envlist =
-    py{37,38,39,310}
+    py{38,39,310}
     style
     docs
 
-[testenv:py{37,38,39,310}]
+[testenv:py{38,39,310}]
 deps =
     .[dev]
 commands = python -m pytest
@@ -29,6 +29,5 @@ addopts =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
This PR removes deprecated call to `pkg_resources.get_distribution` with `importlib.metadata.version`.

Note: `__name__` = "ecl_data_io.version", so that can't be used without some stringprocessing e.g.
`version(__name__.split(".")[0])`



Pytest-warnings in my project inb4 changing this^
```
pkg_resources\__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API      
    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)

pkg_resources\__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_
namespace('mpl_toolkits')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

```