### PR TITLE
Drop support for python 3.7

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers=[
     "Development Status :: 1 - Planning",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 isolated_build = True
 envlist =
-    py{37,38,39,310}
+    py{38,39,310}
     style
     docs
 
-[testenv:py{37,38,39,310}]
+[testenv:py{38,39,310}]
 deps =
     .[dev]
 commands = python -m pytest
@@ -29,6 +29,5 @@ addopts =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
In order to fix the deprecation warning in #40 , python 3.7 support must be dropped. Python 3.7 support is in any case difficult as numpy has already dropped support for 3.7. The version has end of life june 2023.