### PR TITLE
substitute np.float128 for np.longdouble

### DIFF
--- a/tests/test_unformatted_write.py
+++ b/tests/test_unformatted_write.py
@@ -59,7 +59,7 @@ def test_write_array_header_not_a_type():
         (np.array([1.0], dtype=np.float64), np.array([1.0], dtype=np.float64)),
         (np.array([True, False], dtype=np.bool_), np.array([-1, 0], dtype=np.int32)),
         (np.array([10, 20], dtype=np.int8), np.array([10, 20], dtype=np.int32)),
-        (np.array([1.0], dtype=np.float128), np.array([1.0], dtype=np.float64)),
+        (np.array([1.0], dtype=np.longdouble), np.array([1.0], dtype=np.float64)),
     ],
 )
 def test_cast_array_to_ecl(array, expected_array):


### PR DESCRIPTION
The dtype "np.float128" is specific to some architectures and is not always available (e.g. Mac M1). However, it can be substituted out with "np.longdouble" which is available on all platforms and does more or less the same (it is an alias).