### PR TITLE
make return types of reading methods more specific

### DIFF
--- a/src/ecl_data_io/array_entry.py
+++ b/src/ecl_data_io/array_entry.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional, Union
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
-    from .types import ArrayValue
+    from .types import ReadArrayValue
 
 
 class EclArray(ABC):
@@ -62,7 +62,7 @@ class EclArray(ABC):
         return self._length  # type: ignore
 
     @abstractmethod
-    def read_array(self) -> "ArrayValue":
+    def read_array(self) -> "ReadArrayValue":
         """
         Read the array from the unformatted ecl file.
 

--- a/src/ecl_data_io/read.py
+++ b/src/ecl_data_io/read.py
@@ -6,10 +6,10 @@ from ecl_data_io.array_entry import EclArray
 from ecl_data_io.format import Format, check_correct_mode, get_stream, guess_format
 
 if TYPE_CHECKING:
-    from .types import ArrayValue
+    from .types import ReadArrayValue
 
 
-def read(*args, **kwargs) -> List[Tuple[str, "ArrayValue"]]:
+def read(*args, **kwargs) -> List[Tuple[str, "ReadArrayValue"]]:
     """
     Read the contents of a ecl file and return a list of
     tuples (keyword, array). Takes the same parameters as

--- a/src/ecl_data_io/types.py
+++ b/src/ecl_data_io/types.py
@@ -47,7 +47,8 @@ class MESS:
     pass
 
 
-ArrayValue = Union[ArrayLike, MESS]
+ReadArrayValue = Union[np.ndarray, MESS]
+WriteArrayValue = Union[ArrayLike, MESS]
 
 
 def to_np_type(type_keyword):

--- a/src/ecl_data_io/write.py
+++ b/src/ecl_data_io/write.py
@@ -4,12 +4,12 @@ from ecl_data_io._formatted.write import formatted_write
 from ecl_data_io._unformatted.write import unformatted_write
 from ecl_data_io.format import Format, check_correct_mode, get_stream
 
-from .types import ArrayValue
+from .types import WriteArrayValue
 
 
 def write(
     filelike,
-    contents: Union[Sequence[Tuple[str, ArrayValue]], Dict[str, ArrayValue]],
+    contents: Union[Sequence[Tuple[str, WriteArrayValue]], Dict[str, WriteArrayValue]],
     fileformat: Format = Format.UNFORMATTED,
 ):
     """


### PR DESCRIPTION
[It is recommended that inputs are as general as possible, while outputs are as specific as possible](https://typing.readthedocs.io/en/latest/source/best_practices.html#arguments-and-return-types). This was not the case, as reading methods essentially returned numpy.typing.ArrayLike which can be, more or less, everything. Since the reading methods always returns either MESS or a numpy array, I created a narrower type for the read output (ReadArrayValue) and a more general one for writing (WriteArrayValue). Not sure if this is the best solutions, so I am open to hear what you think.